### PR TITLE
Prevent Update Override

### DIFF
--- a/src/controllers/service.ts
+++ b/src/controllers/service.ts
@@ -68,7 +68,7 @@ export const update = async (
     return null;
   }
 
-  items[id] = {id, ...itemUpdate};
+  items[id] = {...item, id, ...itemUpdate};
 
   return items[id];
 }


### PR DESCRIPTION
@codemuseKE 
The update function overrides all changes that exist in the store. This means that if the user passes in only a few datasets of `BaseItem` type, the store with `id` will get overwritten.

I have added a clean mutation to update the item with `id` to only update what is needed